### PR TITLE
Add heroku deploy button

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,11 +15,8 @@ $ heroku plugins:install heroku-kafka
 
 Create a heroku app with Kafka attached:
 
-```
-$ heroku apps:create your-cool-app-name
-$ heroku git:remote -a your-cool-app-name
-$ heroku addons:create heroku-kafka:basic-0
-```
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 
 Create the sample topic and consumer group. By default, the topic will have 8 partitions:
 
@@ -28,11 +25,10 @@ $ heroku kafka:topics:create messages
 $ heroku kafka:consumer-groups:create heroku-kafka-demo
 ```
 
-Deploy to Heroku and open the app:
+Open the app:
 
 ```
-$ git push heroku main
-$ heroku open
+$ heroku open --app=<MY_APP>
 ```
 
 You can send messages via the web UI or the CLI:

--- a/app.json
+++ b/app.json
@@ -1,0 +1,16 @@
+{
+    "name": "Kafka Demo Ruby",
+    "description": "A Kafka Ruby Demo",
+    "keywords": [
+      "Kafka",
+      "Ruby",
+      "Demo"
+    ],
+    "website": "https://heroku.com/",
+    "success_url": "/",
+    "addons": [
+      {
+        "plan": "heroku-kafka:basic-0"
+      }
+    ]
+  }

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
     "name": "Kafka Demo Ruby",
-    "description": "A Kafka Ruby Demo",
+    "description": "Demo showing how to set up Kafka on Heroku, using Ruby",
     "keywords": [
       "Kafka",
       "Ruby",


### PR DESCRIPTION
Adds a button to deploy to heroku and updates readme to use it.

### Testing:

Followed the readme. After deploying via the button:

```shell

ekozil@ekozil-ltmg3a2 heroku-kafka-demo-ruby % heroku kafka:topics:create --app=kafka-demo-ruby-ekozil messages 
Creating topic messages with compaction disabled and retention time 1 day on kafka-clear-43111... done
Use `heroku kafka:topics:info messages` to monitor your topic.
Your topic is using the prefix sanjuan-61872.. Learn more in Dev Center:
  https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku#connecting-kafka-prefix                                                                                                      
ekozil@ekozil-ltmg3a2 heroku-kafka-demo-ruby % heroku kafka:consumer-groups:create --app=kafka-demo-ruby-ekozil heroku-kafka-demo
Creating consumer group heroku-kafka-demo... done
Use `heroku kafka:consumer-groups` to list your consumer groups.
ekozil@ekozil-ltmg3a2 heroku-kafka-demo-ruby % heroku open --app=kafka-demo-ruby-ekozil             

```

<img width="1372" alt="Screenshot 2024-03-22 at 1 37 55 PM" src="https://github.com/heroku/heroku-kafka-demo-ruby/assets/152196227/f8afba52-f6de-46ec-ab11-594ce0f320d1">

